### PR TITLE
Need smaller hmin in ode23s to run ROBER test case

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -457,7 +457,7 @@ function ode23s(F, y0, tspan; reltol = 1.0e-5, abstol = 1.0e-8,
     tdir = sign(tfinal - t)
 
     hmax = abs(tfinal - t)/10
-    hmin = abs(tfinal - t)/1e9
+    hmin = abs(tfinal - t)/1e18
     h = tdir*abs(tfinal - t)/100  # initial step size
 
     y = y0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,23 @@ for solver in solvers
     @test maximum(abs(ys-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
 end
 
+# rober testcase from http://www.unige.ch/~hairer/testset/testset.html
+let
+    println("ROBER test case")
+    function f(t, y)
+        ydot = similar(y)
+        ydot[1] = -0.04*y[1] + 1.0e4*y[2]*y[3]
+        ydot[3] = 3.0e7*y[2]*y[2]
+        ydot[2] = -ydot[1] - ydot[3]
+        ydot
+    end
+    t = [0., 1e11]
+    t,y = ode23s(f, [1.0, 0.0, 0.0], t; abstol=1e-8, reltol=1e-8)
+
+    refsol = [0.2083340149701255e-07,
+              0.8333360770334713e-13,
+              0.9999999791665050] # reference solution at tspan[2]
+    @test norm(refsol-y[end], Inf) < 2e-10
+end
+
 println("All looks OK")


### PR DESCRIPTION
To run the ROBER testcase from
http://www.unige.ch/~hairer/testset/testset.html
hmin <= 1e-17

See new testcase in test/runtest.jl