### PR TITLE
Fix type stability for tout in oderkf and use push! instead of concatenation. 

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -61,7 +61,7 @@ function ode23(F, y0, tspan; reltol = 1.e-5, abstol = 1.e-8)
     hmax = abs(0.1*(tfinal-t))
     y = y0
 
-    tout = t
+    tout = [t]
     yout = Array(typeof(y0),1)
     yout[1] = y
 
@@ -105,7 +105,7 @@ function ode23(F, y0, tspan; reltol = 1.e-5, abstol = 1.e-8)
         if err <= reltol
             t = tnew
             y = ynew
-            tout = [tout; t]
+            push!(tout, t)
             push!(yout, y)
             s1 = s4   # Reuse final function value to start new step
         end
@@ -200,7 +200,7 @@ function oderkf(F, x0, tspan, p, a, bs, bp; reltol = 1.0e-5, abstol = 1.0e-8)
     hmin = abs(tfinal - t)/1e9
     h = tdir*abs(tfinal - t)/100  # initial guess at a step size
     x = x0
-    tout = t            # first output time
+    tout = [t]            # first output time
     xout = Array(typeof(x0), 1)
     xout[1] = x         # first output solution
 
@@ -239,7 +239,7 @@ function oderkf(F, x0, tspan, p, a, bs, bp; reltol = 1.0e-5, abstol = 1.0e-8)
         if delta <= tau
             t = t + h
             x = xp    # <-- using the higher order estimate is called 'local extrapolation'
-            tout = [tout; t]
+            push!(tout, t)
             push!(xout, x)
 
             # Compute the slopes by computing the k[:,j+1]'th column based on the previous k[:,1:j] columns
@@ -261,7 +261,7 @@ function oderkf(F, x0, tspan, p, a, bs, bp; reltol = 1.0e-5, abstol = 1.0e-8)
     end # while (t < tfinal) & (h >= hmin)
 
     if abs(t) < abs(tfinal)
-      println("Step size grew too small. t=", t, ", h=", abs(h), ", x=", x)
+        error("Step size grew too small. t=$t, h=$(abs(h)), x=$x")
     end
 
     return tout, xout
@@ -393,7 +393,7 @@ function ode4(F, x0, tspan)
         # Integrate
         x[i+1] = x[i] + 1/6 .*h[i].*sum(midxdot)
     end
-    return [tspan], x
+    return vcat(tspan), x
 end
 
 ###############################################################################
@@ -581,7 +581,7 @@ function oderosenbrock(F, x0, tspan, gamma, a, b, c; jacobian=nothing)
         end
         solstep += 1
     end
-    return [tspan], x
+    return vcat(tspan), x
 end
 
 
@@ -656,7 +656,7 @@ function ode_ms(F, x0, tspan, order::Integer)
             x[i+1] += h[i]*b[steporder, j]*xdot[i-(steporder-1) + (j-1)]
         end
     end
-    return [tspan], x
+    return vcat(tspan), x
 end
 
 # Use order 4 by default

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,19 +27,19 @@ for solver in solvers
     # dy
     # -- = 6 ==> y = 6t
     # dt
-    t,y=solver((t,y)->6, 0., [0:.1:1])
+    t,y=solver((t,y)->6, 0., [0:.1:1;])
     @test maximum(abs(y-6t)) < tol
 
     # dy
     # -- = 2t ==> y = t.^2
     # dt
-    t,y=solver((t,y)->2t, 0., [0:.001:1])
+    t,y=solver((t,y)->2t, 0., [0:.001:1;])
     @test maximum(abs(y-t.^2)) < tol
 
     # dy
     # -- = y ==> y = y0*e.^t
     # dt
-    t,y=solver((t,y)->y, 1., [0:.001:1])
+    t,y=solver((t,y)->y, 1., [0:.001:1;])
     @test maximum(abs(y-e.^t)) < tol
 
     # dv       dw
@@ -47,7 +47,7 @@ for solver in solvers
     # dt       dt
     #
     # y = [v, w]
-    t,y=solver((t,y)->[-y[2], y[1]], [1., 2.], [0:.001:2*pi])
+    t,y=solver((t,y)->[-y[2]; y[1]], [1., 2.], [0:.001:2*pi;])
     ys = hcat(y...).'   # convert Vector{Vector{Float}} to Matrix{Float}
     @test maximum(abs(ys-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
 end


### PR DESCRIPTION
Use vcat instead of old range to vector convertion syntax.

This pr does break 0.3 compatibility and therefore supersedes #54.