### PR TITLE
Add passing of parameters to `ode23`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.2
 Polynomials
+Docile
+

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -19,38 +19,42 @@ export ode4s, ode4ms, ode4
 #    ode4ms, ode_ms
 
 
-#ODE23  Solve non-stiff differential equations.
+# ode23: Solve non-stiff differential equations.
 #
-#   ODE23(F,TSPAN,Y0) with TSPAN = [T0 TFINAL] integrates the system
-#   of differential equations dy/dt = f(t,y) from t = T0 to t = TFINAL.
-#   The initial condition is y(T0) = Y0.
+#   ode23(f, y0, tspan) with tspan = [t0, t_final] integrates the system
+#   of differential equations dy/dt = f(t,y) from t = t0 to t = t_final.
+#   Here, y may be a scalar or a vector.
+#   The initial condition is y(t0) = y0.
 #
 #   The first argument, F, is a function handle or an anonymous function
 #   that defines f(t,y).  This function must have two input arguments,
-#   t and y, and must return a column vector of the derivatives, dy/dt.
+#   t and y, and must return a vector of the derivatives, dy/dt.
 #
-#   With two output arguments, [T,Y] = ODE23(...) returns a column
-#   vector T and an array Y where Y(:,k) is the solution at T(k).
+#   ode23 returns the pair (tout, yout),
+#   where tout is the vector of times and yout an array of solutions:
+#   yout[k,:] is the solution at time tout(k)
 #
-#   More than four input arguments, ODE23(F,TSPAN,Y0,RTOL,P1,P2,...),
-#   are passed on to F, F(T,Y,P1,P2,...).
+#   Parameters may be passed through to the function F by adding additional
+#   arguments:
+#   ode23(f, y0, tspan, p1, p2, ...)
+#   calls f(t, y, p1, p2, ...).
 #
-#   ODE23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
+#   Keyword arguments reltol and abstol specify the relative and absolute
+#   tolerances, respectively; their default values are reltol=1.e-5; abstol=1.e-8.
 #
-#   Example
+#   ode23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
+#
+#   Example:
 #      tspan = [0, 2*pi]
 #      y0 = [1, 0]
 #      F = (t, y) -> [0 1; -1 0]*y
-#      ode23(F, tspan, y0)
-#
-#   See also ODE23.
+#      ode23(F, y0, tspan)
 
-# Initialize variables.
 # Adapted from Cleve Moler's textbook
 # http://www.mathworks.com/moler/ncm/ode23tx.m
 function ode23(F, y0, tspan, params...; reltol = 1.e-5, abstol = 1.e-8)
     if reltol == 0
-        warn("setting reltol = 0 gives a step size of zero")
+        warn("Setting reltol = 0 gives a step size of zero")
     end
 
     threshold = abstol / reltol

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -48,7 +48,7 @@ export ode4s, ode4ms, ode4
 # Initialize variables.
 # Adapted from Cleve Moler's textbook
 # http://www.mathworks.com/moler/ncm/ode23tx.m
-function ode23(F, y0, tspan; reltol = 1.e-5, abstol = 1.e-8)
+function ode23(F, y0, tspan, params...; reltol = 1.e-5, abstol = 1.e-8)
     if reltol == 0
         warn("setting reltol = 0 gives a step size of zero")
     end
@@ -69,7 +69,7 @@ function ode23(F, y0, tspan; reltol = 1.e-5, abstol = 1.e-8)
 
     # Compute initial step size.
 
-    s1 = F(t, y)
+    s1 = F(t, y, params...)
     r = norm(s1./max(abs(y), threshold), Inf) + realmin() # TODO: fix type bug in max()
     h = tdir*0.8*reltol^(1/3)/r
 
@@ -89,11 +89,11 @@ function ode23(F, y0, tspan; reltol = 1.e-5, abstol = 1.e-8)
 
         # Attempt a step.
 
-        s2 = F(t+h/2, y+h/2*s1)
-        s3 = F(t+3*h/4, y+3*h/4*s2)
+        s2 = F(t+h/2, y+h/2*s1, params...)
+        s3 = F(t+3*h/4, y+3*h/4*s2, params...)
         tnew = t + h
         ynew = y + h*(2*s1 + 3*s2 + 4*s3)/9
-        s4 = F(tnew, ynew)
+        s4 = F(tnew, ynew, params...)
 
         # Estimate the error.
 

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -2,6 +2,8 @@
 
 module ODE
 
+VERSION < v"0.4-" && using Docile
+
 using Polynomials
 
 ## minimal function export list
@@ -19,47 +21,53 @@ export ode4s, ode4ms, ode4
 #    ode4ms, ode_ms
 
 
-# ode23: Solve non-stiff differential equations.
-#
-#  ode23(f, y0, tspan) with tspan = [t0, t_final] integrates the system
-#  of differential equations dy/dt = f(t,y) from t = t0 to t = t_final.
-#  Here, y may be a scalar or a vector.
-#  The initial condition is y(t0) = y0.
-#
-#  The first argument, F, is a function handle or an anonymous function
-#  that defines f(t,y).  This function must have two input arguments,
-#  t and y, and must return a vector of the derivatives, dy/dt.
-#
-#  ode23 returns the pair (tout, yout),
-#  where tout is the vector of times and yout an array of solutions:
-#  yout[k,:] is the solution at time tout(k)
-#
-#  Parameters may be passed through to the function F by adding additional
-#  arguments:
-#  ode23(f, y0, tspan, p1, p2, ...)
-#  calls f(t, y, p1, p2, ...).
-#
-#  Keyword arguments reltol and abstol specify the relative and absolute
-#  tolerances, respectively; their default values are reltol=1.e-5; abstol=1.e-8.
-#
-#  ode23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
-#
-#  Example:
-#    tspan = [0., 2*pi]
-#    y0 = [1.0, 0.0]
-#    F = (t, y) -> [0.0 1.0; -1.0 0.0]*y
-#    ode23(F, y0, tspan)
-#
-#   Example of passing through parameters:
-#    tspan = [0, 2*pi]
-#    F(t, y, α, β) = -α*y + β
-#    y0 = 1.0
-#    α, β = 1.0, 0.5
-#    ode23(F, y0, tspan, α, β)
+@doc doc"""
+`ode23`: Solve non-stiff differential equations.
 
-# Adapted from Cleve Moler's textbook
-# http://www.mathworks.com/moler/ncm/ode23tx.m
+`ode23(f, y0, tspan)` with `tspan = [t0, t_final]` integrates the system
+of differential equations \$dy/dt = f(t,y)\$ from \$t = t_0\$ to \$t = t_\mathrm{final}\$.
+Here, \$y\$ may be a scalar or a vector.
+The initial condition is \$y(t0) = y_0\$.
 
+The first argument, `F`, is a function that defines \$f(t,y)\$.
+This function must have at least two input arguments,
+`t` and `y`, and must return a vector of the derivatives, \$dy_i/dt\$.
+
+`ode23` returns the tuple `(tout, yout)`,
+where `tout` is the vector of times and yout an array of solutions:
+`yout[k,:]` is the solution at time `tout(k)`.
+
+Parameters may be passed through to the function `F` by adding additional
+arguments:
+`ode23(f, y0, tspan, p1, p2, ...)`
+calls `f(t, y, p1, p2, ...)`.
+
+Keyword arguments `reltol` and `abstol` specify the relative and absolute
+tolerances, respectively; their default values are `reltol=1.e-5`
+and `abstol=1.e-8`.
+
+`ode23` uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
+
+Example of the basic use of `ode23`:
+```
+    tspan = [0., 2*pi]
+    y0 = [1.0, 0.0]
+    F = (t, y) -> [0.0 1.0; -1.0 0.0]*y
+    ode23(F, y0, tspan)
+```
+
+Example of passing through parameters:
+```
+    tspan = [0, 2*pi]
+    F(t, y, α, β) = -α*y + β
+    y0 = 1.0
+    α, β = 1.0, 0.5
+    ode23(F, y0, tspan, α, β)
+```
+
+The code for `ode23` was adapted from Cleve Moler's textbook:
+<http://www.mathworks.com/moler/ncm/ode23tx.m>
+""" ->
 function ode23(F, y0, tspan, params...; reltol = 1.e-5, abstol = 1.e-8)
     if reltol == 0
         warn("Setting reltol = 0 gives a step size of zero")

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -13,7 +13,7 @@ export ode23s
 export ode4s, ode4ms, ode4
 
 ## complete function export list
-#export ode23, ode4,
+# export ode23, ode4,
 #    oderkf, ode45, ode45_dp, ode45_fb, ode45_ck,
 #    oderosenbrock, ode4s, ode4s_kr, ode4s_s,
 #    ode4ms, ode_ms
@@ -21,37 +21,45 @@ export ode4s, ode4ms, ode4
 
 # ode23: Solve non-stiff differential equations.
 #
-#   ode23(f, y0, tspan) with tspan = [t0, t_final] integrates the system
-#   of differential equations dy/dt = f(t,y) from t = t0 to t = t_final.
-#   Here, y may be a scalar or a vector.
-#   The initial condition is y(t0) = y0.
+#  ode23(f, y0, tspan) with tspan = [t0, t_final] integrates the system
+#  of differential equations dy/dt = f(t,y) from t = t0 to t = t_final.
+#  Here, y may be a scalar or a vector.
+#  The initial condition is y(t0) = y0.
 #
-#   The first argument, F, is a function handle or an anonymous function
-#   that defines f(t,y).  This function must have two input arguments,
-#   t and y, and must return a vector of the derivatives, dy/dt.
+#  The first argument, F, is a function handle or an anonymous function
+#  that defines f(t,y).  This function must have two input arguments,
+#  t and y, and must return a vector of the derivatives, dy/dt.
 #
-#   ode23 returns the pair (tout, yout),
-#   where tout is the vector of times and yout an array of solutions:
-#   yout[k,:] is the solution at time tout(k)
+#  ode23 returns the pair (tout, yout),
+#  where tout is the vector of times and yout an array of solutions:
+#  yout[k,:] is the solution at time tout(k)
 #
-#   Parameters may be passed through to the function F by adding additional
-#   arguments:
-#   ode23(f, y0, tspan, p1, p2, ...)
-#   calls f(t, y, p1, p2, ...).
+#  Parameters may be passed through to the function F by adding additional
+#  arguments:
+#  ode23(f, y0, tspan, p1, p2, ...)
+#  calls f(t, y, p1, p2, ...).
 #
-#   Keyword arguments reltol and abstol specify the relative and absolute
-#   tolerances, respectively; their default values are reltol=1.e-5; abstol=1.e-8.
+#  Keyword arguments reltol and abstol specify the relative and absolute
+#  tolerances, respectively; their default values are reltol=1.e-5; abstol=1.e-8.
 #
-#   ode23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
+#  ode23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
 #
-#   Example:
-#      tspan = [0, 2*pi]
-#      y0 = [1, 0]
-#      F = (t, y) -> [0 1; -1 0]*y
-#      ode23(F, y0, tspan)
+#  Example:
+#    tspan = [0., 2*pi]
+#    y0 = [1.0, 0.0]
+#    F = (t, y) -> [0.0 1.0; -1.0 0.0]*y
+#    ode23(F, y0, tspan)
+#
+#   Example of passing through parameters:
+#    tspan = [0, 2*pi]
+#    F(t, y, α, β) = -α*y + β
+#    y0 = 1.0
+#    α, β = 1.0, 0.5
+#    ode23(F, y0, tspan, α, β)
 
 # Adapted from Cleve Moler's textbook
 # http://www.mathworks.com/moler/ncm/ode23tx.m
+
 function ode23(F, y0, tspan, params...; reltol = 1.e-5, abstol = 1.e-8)
     if reltol == 0
         warn("Setting reltol = 0 gives a step size of zero")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,19 @@ for solver in solvers
     @test maximum(abs(ys-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
 end
 
+# Test ode23 with parameters:
+
+solver = ode23
+println("using $solver with parameters")
+# dy
+# -- = -αy ==> y = y0*e.^(-αt)
+# dt
+
+for α in 1.0:1.0:10.
+    t,y=solver((t,y,α)->-α*y, 1., [0:.001:1;], α)
+    @test maximum(abs(y-e.^(-α*t))) < tol
+end
+
 # rober testcase from http://www.unige.ch/~hairer/testset/testset.html
 let
     println("ROBER test case")
@@ -70,5 +83,8 @@ let
               0.9999999791665050] # reference solution at tspan[2]
     @test norm(refsol-y[end], Inf) < 2e-10
 end
+
+
+
 
 println("All looks OK")


### PR DESCRIPTION
This adds to `ode23` the  possibility to pass parameters through to the function to integrate, via parameter splatting. This is useful functionality; see, for example, [this post on Julia-users](
https://groups.google.com/forum/#!searchin/julia-users/Error$20array$20could$20not$20be$20broadcast$20to$20a$20common$20size/julia-users/4Yj2CnvPB_s/5gsUhsRyaiEJ).

I also updated (read: corrected) the documentation to use the Julia, not MATLAB, convention, and to not give `InexactError`s.

The last commit updates the documentation to use the `@doc` style.