### PR TITLE
Move coverage stat submission to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("ODE"); Pkg.test("ODE"; coverage=true)';
+after_success:
     - julia -e 'cd(Pkg.dir("ODE")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';


### PR DESCRIPTION
As indicated in https://github.com/IainNZ/Coverage.jl/issues/54#issuecomment-87842579.

This might not be enough to fix the build script, but I don't know of any way to test it other than to push a PR.