### PR TITLE
Fix 0.4 deprecated bindings

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -108,7 +108,7 @@ function make_consistent_types(fn, y0, tspan, btab::Tableau)
     #
     # Returns
     # - Et: eltype of time, needs to be a real "continuous" type, at
-    #       the moment a FloatingPoint
+    #       the moment a AbstractFloat
     # - Eyf: suitable eltype of y and f(t,y)
     #   --> both of these are set to typeof(y0[1]/(tspan[end]-tspan[1]))
     # - Ty: container type of y0
@@ -124,12 +124,12 @@ function make_consistent_types(fn, y0, tspan, btab::Tableau)
 
     Et = eltype(tspan)
     @assert Et<:Real
-    if !(Et<:FloatingPoint)
+    if !(Et<:AbstractFloat)
         Et = promote_type(Et, Float64)
     end
 
     # if all are Floats, make them the same
-    if Et<:FloatingPoint &&  Eyf<:FloatingPoint
+    if Et<:AbstractFloat &&  Eyf<:AbstractFloat
         Et = promote_type(Et, Eyf)
         Eyf = Et
     end

--- a/test/interface-tests.jl
+++ b/test/interface-tests.jl
@@ -3,6 +3,9 @@
 ################################################################################
 # This is to test a scalar-like state variable
 # (due to @acroy: https://gist.github.com/acroy/28be4f2384d01f38e577)
+
+import Base: +, -, *, /, .+, .-, .*, ./
+
 const delta0 = 0.
 const V0 = 1.
 const g0 = 0.
@@ -12,10 +15,10 @@ immutable CompSol
   rho::Matrix{Complex128}
   x::Float64
   p::Float64
- 
+
   CompSol(r,x,p) = new(copy(r),x,p)
 end
- 
+
 # ... which has to support the following operations
 # to work with odeX
 Base.norm(y::CompSol, p::Float64) = maximum([Base.norm(y.rho, p) abs(y.x) abs(y.p)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Base.Test
 tol = 1e-2
 
 solvers = [
-           ## Non-stiff           
+           ## Non-stiff
            # fixed step
            ODE.ode1,
            ODE.ode2_midpoint,
@@ -39,7 +39,7 @@ for solver in solvers
     # dt
     t,y=solver((t,y)->2t, 0., [0:.001:1;])
     @test maximum(abs(y-t.^2)) < tol
-    
+
 
     # dy
     # -- = y ==> y = y0*e.^t
@@ -49,7 +49,7 @@ for solver in solvers
 
     t,y=solver((t,y)->y, 1., [1:-.001:0;])
     @test maximum(abs(y-e.^(t-1))) < tol
- 
+
     # dv       dw
     # -- = -w, -- = v ==> v = v0*cos(t) - w0*sin(t), w = w0*cos(t) + v0*sin(t)
     # dt       dt


### PR DESCRIPTION
Also removed some white space and explicitly import operators from Base.