### PR TITLE
While loop in ode23s correctly handles negative initial time

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -250,8 +250,8 @@ function ode23s(F, y0, tspan; reltol = 1.0e-5, abstol = 1.0e-8,
 
     # initialization
     t = tspan[1]
-    tfinal = tspan[end]
 
+    tfinal = tspan[end]
 
     h = initstep
     if h == 0.
@@ -261,7 +261,7 @@ function ode23s(F, y0, tspan; reltol = 1.0e-5, abstol = 1.0e-8,
         tdir = sign(tfinal - t)
         F0 = F(t,y0)
     end
-    h = tdir*min(h, maxstep)
+    h = tdir * min(abs(h), maxstep)
 
     y = y0
     tout = Array(typeof(t), 1)
@@ -272,7 +272,7 @@ function ode23s(F, y0, tspan; reltol = 1.0e-5, abstol = 1.0e-8,
 
     J = jac(t,y)    # get Jacobian of F wrt y
 
-    while abs(t) < abs(tfinal) && minstep < abs(h)
+    while abs(t - tfinal) > 0 && minstep < abs(h)
         if abs(t-tfinal) < abs(h)
             h = tfinal - t
         end
@@ -299,7 +299,7 @@ function ode23s(F, y0, tspan; reltol = 1.0e-5, abstol = 1.0e-8,
         F2 = F(t + h, ynew)
         k3 = W\(F2 - e32*(k2 - F1) - 2*(k1 - F0) + T )
 
-        err = (h/6)*norm(k1 - 2*k2 + k3) # error estimate
+        err = (abs(h)/6)*norm(k1 - 2*k2 + k3) # error estimate
         delta = max(reltol*max(norm(y),norm(ynew)), abstol) # allowable error
 
         # check if new solution is acceptable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,10 @@ for solver in solvers
     @test maximum(abs(ys-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
 end
 
+# Test negative starting times ODE.ode23s
+@assert length(ODE.ode23s((t,y)->[-y[2]; y[1]], [1., 2.], [-5., 0])[1]) > 1
+
+
 # rober testcase from http://www.unige.ch/~hairer/testset/testset.html
 let
     println("ROBER test case")


### PR DESCRIPTION
Currently, running `ode23s` when `abs(tspan[1]) > abs(tspan[end])` will prevent the main while loop from running. For example, 

```julia
ODE.ode23s((t,y)->[y[2]; -y[1]], [1., 0.], [-5., 0])
```

just returns the initial time point on master. This commit adds a test and changes the while loop condition to work for any `tspan`.